### PR TITLE
Fixes namespace of package and interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Psr\\Http\\Factory\\": "src/"
+            "Psr\\Http\\Message\\": "src/"
         }
     },
     "extra": {

--- a/src/RequestFactoryInterface.php
+++ b/src/RequestFactoryInterface.php
@@ -1,9 +1,6 @@
 <?php
 
-namespace Psr\Http\Factory;
-
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\UriInterface;
+namespace Psr\Http\Message;
 
 interface RequestFactoryInterface
 {

--- a/src/ResponseFactoryInterface.php
+++ b/src/ResponseFactoryInterface.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Psr\Http\Factory;
-
-use Psr\Http\Message\ResponseInterface;
+namespace Psr\Http\Message;
 
 interface ResponseFactoryInterface
 {

--- a/src/ServerRequestFactoryInterface.php
+++ b/src/ServerRequestFactoryInterface.php
@@ -1,9 +1,6 @@
 <?php
 
-namespace Psr\Http\Factory;
-
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\UriInterface;
+namespace Psr\Http\Message;
 
 interface ServerRequestFactoryInterface
 {

--- a/src/StreamFactoryInterface.php
+++ b/src/StreamFactoryInterface.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Psr\Http\Factory;
-
-use Psr\Http\Message\StreamInterface;
+namespace Psr\Http\Message;
 
 interface StreamFactoryInterface
 {

--- a/src/UploadedFileFactoryInterface.php
+++ b/src/UploadedFileFactoryInterface.php
@@ -1,9 +1,6 @@
 <?php
 
-namespace Psr\Http\Factory;
-
-use Psr\Http\Message\StreamInterface;
-use Psr\Http\Message\UploadedFileInterface;
+namespace Psr\Http\Message;
 
 interface UploadedFileFactoryInterface
 {

--- a/src/UriFactoryInterface.php
+++ b/src/UriFactoryInterface.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Psr\Http\Factory;
-
-use Psr\Http\Message\UriInterface;
+namespace Psr\Http\Message;
 
 interface UriFactoryInterface
 {


### PR DESCRIPTION
When I imported the interfaces, I forgot to look at the spec, which specifically places the factory interfaces in the same namespace as PSR-7. This patch updates the namespace of all interfaces in this package to `Psr\Http\Message`, and updates the package autoloading configuration to do likewise.