### PR TITLE
Update ResponseFactoryInterface.php

### DIFF
--- a/src/ResponseFactoryInterface.php
+++ b/src/ResponseFactoryInterface.php
@@ -14,5 +14,5 @@ interface ResponseFactoryInterface
      *
      * @return ResponseInterface
      */
-    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface;
+    public function createResponse(int $code = 200, string $reasonPhrase = null): ResponseInterface;
 }


### PR DESCRIPTION
"Reason phrase to associate with status code
in generated response; if none is provided implementations MAY use
the defaults as suggested in the HTTP specification."

"None" is ambiguous term, "empty" is more appropriate with current implementation.
But if you want let developers set empty reason or default message, null is more efficient.
Thank you.