### PR TITLE
docs: Standardize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository holds all interfaces related to [PSR-17 (HTTP Factories)][psr-ur
 
 Note that this is not a HTTP Factory implementation of its own. It is merely interfaces that describe the components of a HTTP Factory.
 
-You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+The installable [package][package-url] and [implementations][implementation-url] are listed on Packagist.
 
 [psr-url]: https://www.php-fig.org/psr/psr-17/
 [package-url]: https://packagist.org/packages/psr/http-factory

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 HTTP Factories
 ==============
 
-This repository holds all interfaces related to [PSR-17 (HTTP Message Factories)][psr-17]. 
-Please refer to the specification for a description.
+This repository holds all interfaces related to [PSR-17 (HTTP Factories)][psr-url].
 
-You can find implementations of the specification by looking for packages providing the 
-[psr/http-factory-implementation](https://packagist.org/providers/psr/http-factory-implementation) virtual package.
+Note that this is not a HTTP Factory implementation of its own. It is merely interfaces that describe the components of a HTTP Factory.
 
-[psr-17]: https://www.php-fig.org/psr/psr-17/
+You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+
+[psr-url]: https://www.php-fig.org/psr/psr-17/
+[package-url]: https://packagist.org/packages/psr/http-factory
+[implementation-url]: https://packagist.org/providers/psr/http-factory-implementation


### PR DESCRIPTION
What:
Standardizes the README file providing a common language and an implementation link.

Why:
There are differences between PSR's READMEs in regarding language and the lacking of implementations references. So I've updated all READMEs using the https://github.com/php-fig/http-factory as base.