### PR TITLE
Support `psr/http-message` v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
If accepted, this PR updates `composer.json` to support `psr/http-message` v2.

```diff
- "psr/http-message": "^1.0"
+ "psr/http-message": "^1.0 || ^2.0"
```