### PR TITLE
improve package description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "psr/http-factory",
-    "description": "Common interfaces for PSR-7 HTTP message factories",
+    "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
     "keywords": [
         "psr",
         "psr-7",


### PR DESCRIPTION
i noticed that the description on https://packagist.org/packages/psr/http-factory does not mention PSR-17. that only shows up below in the readme. i think the description there is taken from the composer.json.