### PR TITLE
Add explicit nullable type and bump minimal PHP version to 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/php-fig/http-factory"
     },
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1",
         "psr/http-message": "^1.0 || ^2.0"
     },
     "autoload": {

--- a/src/UploadedFileFactoryInterface.php
+++ b/src/UploadedFileFactoryInterface.php
@@ -15,10 +15,10 @@ interface UploadedFileFactoryInterface
      *
      * @param StreamInterface $stream Underlying stream representing the
      *     uploaded file content.
-     * @param int $size in bytes
+     * @param int|null $size in bytes
      * @param int $error PHP file upload error
-     * @param string $clientFilename Filename as provided by the client, if any.
-     * @param string $clientMediaType Media type as provided by the client, if any.
+     * @param string|null $clientFilename Filename as provided by the client, if any.
+     * @param string|null $clientMediaType Media type as provided by the client, if any.
      *
      * @return UploadedFileInterface
      *
@@ -26,9 +26,9 @@ interface UploadedFileFactoryInterface
      */
     public function createUploadedFile(
         StreamInterface $stream,
-        int $size = null,
+        ?int $size = null,
         int $error = \UPLOAD_ERR_OK,
-        string $clientFilename = null,
-        string $clientMediaType = null
+        ?string $clientFilename = null,
+        ?string $clientMediaType = null
     ): UploadedFileInterface;
 }


### PR DESCRIPTION
Goes in pair with the errata of the meta-document: https://github.com/php-fig/fig-standards/pull/1321